### PR TITLE
feat : 메인페이지 카드, 태그 리스트 API 구현

### DIFF
--- a/src/main/java/org/soptcollab/web1/hyundaicard/CardImageDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/CardImageDataLoader.java
@@ -1,0 +1,84 @@
+package org.soptcollab.web1.hyundaicard;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.Image.Image;
+import org.soptcollab.web1.hyundaicard.Image.ImageRepository;
+import org.soptcollab.web1.hyundaicard.api.service.s3.S3Service;
+import org.soptcollab.web1.hyundaicard.domain.card.Brand;
+import org.soptcollab.web1.hyundaicard.domain.card.Card;
+import org.soptcollab.web1.hyundaicard.domain.card.CardRepository;
+import org.soptcollab.web1.hyundaicard.domain.card.PaymentNetwork;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class CardImageDataLoader implements CommandLineRunner {
+
+  private final S3Service s3Service;
+  private final ImageRepository imageRepository;
+  private final CardRepository cardRepository;
+
+  @Override
+  public void run(String... args) {
+    if (cardRepository.count() > 0) {
+      return;
+    }
+
+    // 1) S3에서 card-thumbnails 디렉터리의 URL 리스트 가져오기
+    List<String> urls = s3Service.listFiles("card-thumbnails");
+
+    // 2) Image 엔티티로 저장
+    List<Image> images = urls.stream()
+        .map(url -> {
+          String fileName = url.substring(url.lastIndexOf('/') + 1);
+          String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
+          return Image.builder()
+              .url(url)
+              .extension(extension)
+              .width(300)
+              .height(180)
+              .build();
+        })
+        .toList();
+    imageRepository.saveAll(images);
+
+    // 3) Brand, PaymentNetwork 순환 배열 준비
+    Brand[] brands = Brand.values();
+    PaymentNetwork[] networks = PaymentNetwork.values();
+
+    // 4) Image 리스트 인덱스를 활용해 Card 더미 생성
+    List<Card> cards = IntStream.range(0, images.size())
+        .mapToObj(idx -> {
+          Image img = images.get(idx);
+
+          // URL에서 파일명 → displayName 생성
+          String fileName = img.getUrl().substring(img.getUrl().lastIndexOf('/') + 1);
+          String base = fileName.replace("card_", "")
+              .replace("." + img.getExtension(), "");
+          String displayName = base.replace('_', ' ');
+
+          Brand brand = brands[idx % brands.length];
+          PaymentNetwork network = networks[idx % networks.length];
+          String benefits = brand.getSlogan();
+          String buttonNote = "지금 신청하기";
+
+          return Card.builder()
+              .name(displayName)
+              .brand(brand)
+              .paymentNetwork(network)
+              .benefits(benefits)
+              .buttonNote(buttonNote)
+              .image(img)
+              .build();
+        })
+        .toList();
+    cardRepository.saveAll(cards);
+
+    System.out.println(">>> S3 기반 더미 Card & Image 로드 완료!");
+  }
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/HyundaiCardApplication.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/HyundaiCardApplication.java
@@ -2,7 +2,9 @@ package org.soptcollab.web1.hyundaicard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HyundaiCardApplication {
 

--- a/src/main/java/org/soptcollab/web1/hyundaicard/Image/Image.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/Image/Image.java
@@ -15,10 +15,10 @@ import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder @AllArgsConstructor
 public class Image extends BaseEntity {
 
-  @Id @GeneratedValue(strategy = GenerationType.UUID)
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
   @Column(name = "IMAGE_ID")
   public String id;
 
@@ -34,8 +34,12 @@ public class Image extends BaseEntity {
   // 이미지 높이
   public Integer height;
 
-
-
-
-
+  @Builder
+  public Image(final String url, final String extension, final Integer width,
+      final Integer height) {
+    this.url = url;
+    this.extension = extension;
+    this.width = width;
+    this.height = height;
+  }
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/Image/Image.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/Image/Image.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
@@ -13,6 +15,7 @@ import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder @AllArgsConstructor
 public class Image extends BaseEntity {
 
   @Id @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/org/soptcollab/web1/hyundaicard/TagDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/TagDataLoader.java
@@ -1,0 +1,69 @@
+package org.soptcollab.web1.hyundaicard;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.tag.Category;
+import org.soptcollab.web1.hyundaicard.tag.Tag;
+import org.soptcollab.web1.hyundaicard.tag.TagRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class TagDataLoader implements CommandLineRunner {
+
+  private final TagRepository tagRepository;
+
+  @Override
+  public void run(String... args) throws Exception {
+    if (tagRepository.count() > 0) {
+      return;  // 이미 데이터가 있으면 스킵
+    }
+
+    List<Tag> dummyTags = List.of(
+        Tag.builder()
+            .name("온라인 쇼핑")
+            .code("ONLINE_SHOPPING")
+            .category(Category.SHOPPING_CONSUMPTION)        // 쇼핑/소비
+            .displayOrder(1)
+            .hoverText("온라인 쇼핑몰 결제 시 추가 적립")
+            .build(),
+
+        Tag.builder()
+            .name("여행")
+            .code("TRAVEL")
+            .category(Category.TRAVEL_GLOBAL)               // 여행/글로벌
+            .displayOrder(2)
+            .hoverText("국내 여행 관련 혜택")
+            .build(),
+
+        Tag.builder()
+            .name("차량 관리")
+            .code("VEHICLE_MAINTENANCE")
+            .category(Category.MOVEMENT_TRANSPORTATION)      // 이동/교통
+            .displayOrder(3)
+            .hoverText("차량 정비·검사 시 혜택")
+            .build(),
+
+        Tag.builder()
+            .name("커피")
+            .code("COFFEE")
+            .category(Category.LIFESTYLE_CONVENIENCE)       // 생활/편의
+            .displayOrder(4)
+            .hoverText("카페 이용 시 적립 또는 할인")
+            .build(),
+
+        Tag.builder()
+            .name("개인사업자")
+            .code("SELF_EMPLOYED")
+            .category(Category.FINANCE_BUSINESS)            // 금융/사업
+            .displayOrder(5)
+            .hoverText("개인사업자 결제 시 전용 혜택")
+            .build()
+
+    );
+
+    tagRepository.saveAll(dummyTags);
+
+  }
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
@@ -18,12 +18,6 @@ public class CardController {
 
   private final CardService cardService;
 
-  @GetMapping("/card")
-  public ResponseEntity<ApiResponse<String>> test() {
-    return ResponseEntity.ok(ApiResponse.success("테스트"));
-  }
-
-
   /**
    * @return 메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.
    */
@@ -31,11 +25,9 @@ public class CardController {
   public ResponseEntity<ApiResponse<List<CardResponseDto>>> getCardList() {
 
     List<CardResponseDto> cards = cardService.findAll();
+
     return ResponseEntity.ok(ApiResponse.success(cards));
-
   }
-
-
 }
 
 

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
@@ -1,17 +1,41 @@
 package org.soptcollab.web1.hyundaicard.api.controller.card;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.api.service.card.CardService;
+import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardResponseDto;
 import org.soptcollab.web1.hyundaicard.global.common.response.ApiResponse;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class CardController {
 
+  private final CardService cardService;
+
   @GetMapping("/card")
-  public HttpEntity<ApiResponse<String>> cardList() {
+  public ResponseEntity<ApiResponse<String>> test() {
     return ResponseEntity.ok(ApiResponse.success("테스트"));
   }
 
+
+  /**
+   * @return 메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.
+   */
+  @GetMapping("/cards")
+  public ResponseEntity<ApiResponse<List<CardResponseDto>>> getCardList() {
+
+    List<CardResponseDto> cards = cardService.findAll();
+    return ResponseEntity.ok(ApiResponse.success(cards));
+
+  }
+
+
 }
+
+

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/tag/TagController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/tag/TagController.java
@@ -1,0 +1,27 @@
+package org.soptcollab.web1.hyundaicard.api.controller.tag;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.api.service.tag.TagService;
+import org.soptcollab.web1.hyundaicard.api.service.tag.dto.TagResponseDto;
+import org.soptcollab.web1.hyundaicard.global.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+
+  private final TagService tagService;
+
+  @GetMapping("/tags")
+  public ResponseEntity<ApiResponse<List<TagResponseDto>>> getTags(){
+
+    List<TagResponseDto> tagList = tagService.findAll();
+    return ResponseEntity.ok(ApiResponse.success(tagList));
+
+  }
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/tag/TagController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/tag/TagController.java
@@ -16,12 +16,10 @@ public class TagController {
   private final TagService tagService;
 
   @GetMapping("/tags")
-  public ResponseEntity<ApiResponse<List<TagResponseDto>>> getTags(){
+  public ResponseEntity<ApiResponse<List<TagResponseDto>>> getTags() {
 
     List<TagResponseDto> tagList = tagService.findAll();
+
     return ResponseEntity.ok(ApiResponse.success(tagList));
-
   }
-
-
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
@@ -1,0 +1,25 @@
+package org.soptcollab.web1.hyundaicard.api.service.card;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardResponseDto;
+import org.soptcollab.web1.hyundaicard.domain.card.Card;
+import org.soptcollab.web1.hyundaicard.domain.card.CardRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CardService {
+
+  private final CardRepository cardRepository;
+
+  public List<CardResponseDto> findAll() {
+    return cardRepository.findAll().stream()
+        .limit(15) //15개까지만 조회
+        .map(card -> CardResponseDto.from(card))
+        .collect(Collectors.toList());
+  }
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
@@ -15,11 +15,10 @@ public class CardService {
   private final CardRepository cardRepository;
 
   public List<CardResponseDto> findAll() {
+
     return cardRepository.findAll().stream()
         .limit(15) //15개까지만 조회
         .map(card -> CardResponseDto.from(card))
         .collect(Collectors.toList());
   }
-
-
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardResponseDto.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardResponseDto.java
@@ -1,0 +1,17 @@
+package org.soptcollab.web1.hyundaicard.api.service.card.dto;
+
+import org.soptcollab.web1.hyundaicard.domain.card.Card;
+
+public record CardResponseDto(
+    String imageUrl,//"{이미지 url}",
+    String name, //"the Red"
+    String description, //"현대카드의 오리지널리티를 담은 카드"
+    String brand //"Hyundai Originals"
+) {
+
+  public static CardResponseDto from(Card c){
+    return new CardResponseDto(c.getImage().getUrl(), c.getName(), c.getBrand().getSlogan(),
+        c.getBrand().name());
+  }
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardResponseDto.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardResponseDto.java
@@ -2,16 +2,15 @@ package org.soptcollab.web1.hyundaicard.api.service.card.dto;
 
 import org.soptcollab.web1.hyundaicard.domain.card.Card;
 
-public record CardResponseDto(
-    String imageUrl,//"{이미지 url}",
-    String name, //"the Red"
-    String description, //"현대카드의 오리지널리티를 담은 카드"
-    String brand //"Hyundai Originals"
+public record CardResponseDto(String imageUrl,//"{이미지 url}",
+                              String name, //"the Red"
+                              String description, //"현대카드의 오리지널리티를 담은 카드"
+                              String brand //"Hyundai Originals"
 ) {
 
-  public static CardResponseDto from(Card c){
+  public static CardResponseDto from(Card c) {
+
     return new CardResponseDto(c.getImage().getUrl(), c.getName(), c.getBrand().getSlogan(),
         c.getBrand().name());
   }
-
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/s3/S3Service.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/s3/S3Service.java
@@ -105,16 +105,20 @@ public class S3Service {
 
   /**
    * 1) 단일 파일을 S3에서 가져오기
+   *
    * @param fileName S3에 저장된 전체 경로
    * @return S3Object (InputStream 등을 직접 사용 가능)
    */
   public S3Object getFile(String fileName) {
+
     log.info("Fetching file from S3: {}", fileName);
+
     return amazonS3.getObject(bucket, fileName);
   }
 
   /**
    * 2) 특정 디렉터리의 모든 파일 URL 목록 조회
+   *
    * @param dirName 폴더 경로
    * @return 접근 가능한 URL 리스트
    */
@@ -130,9 +134,6 @@ public class S3Service {
         .map(key -> amazonS3.getUrl(bucket, key).toString())
         .collect(Collectors.toList());
   }
-
-
-
 
 
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/TagService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/TagService.java
@@ -13,12 +13,10 @@ public class TagService {
 
   private final TagRepository tagRepository;
 
-  public List<TagResponseDto> findAll(){
+  public List<TagResponseDto> findAll() {
+
     return tagRepository.findAll().stream()
         .map(tag -> TagResponseDto.from(tag))
         .collect(Collectors.toList());
-
   }
-
-
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/TagService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/TagService.java
@@ -1,0 +1,24 @@
+package org.soptcollab.web1.hyundaicard.api.service.tag;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.api.service.tag.dto.TagResponseDto;
+import org.soptcollab.web1.hyundaicard.tag.TagRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+  private final TagRepository tagRepository;
+
+  public List<TagResponseDto> findAll(){
+    return tagRepository.findAll().stream()
+        .map(tag -> TagResponseDto.from(tag))
+        .collect(Collectors.toList());
+
+  }
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/dto/TagResponseDto.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/tag/dto/TagResponseDto.java
@@ -1,0 +1,17 @@
+package org.soptcollab.web1.hyundaicard.api.service.tag.dto;
+
+import org.soptcollab.web1.hyundaicard.tag.Tag;
+
+public record TagResponseDto(
+    String category,
+    String name,
+    String hoverText,
+    Integer displayOrder
+) {
+
+  public static TagResponseDto from(Tag t) {
+    return new TagResponseDto(t.getCategory().getType(),
+        t.getName(), t.getHoverText(), t.getDisplayOrder());
+  }
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/cardtag/CardTag.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/cardtag/CardTag.java
@@ -1,0 +1,41 @@
+package org.soptcollab.web1.hyundaicard.cardtag;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.soptcollab.web1.hyundaicard.domain.card.Card;
+import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
+import org.soptcollab.web1.hyundaicard.tag.Tag;
+
+@Entity
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CardTag extends BaseEntity {
+
+  @Id @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @ManyToOne
+  @JoinColumn(name = "CARD_ID")
+  private Card card; // CardTag 의 card 가 fk 와 매핑
+
+  @ManyToOne
+  @JoinColumn(name = "TAG_ID")
+  private Tag tag; // CardTag 의 Tag 가 fk 와 매핑
+
+  // Card 와 CardTag 는 양방향이므로, 연관관계 편의 메소드 설정
+  public void linkCard(Card card){
+    this.card = card;
+    card.getCardTags().add(this);
+  }
+
+  // Tag 와 CardTag 는 일단 단방향으로 설정했으므로, 연관관계 편의 메소드는 추후 설정 고려
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Brand.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Brand.java
@@ -1,0 +1,20 @@
+package org.soptcollab.web1.hyundaicard.domain.card;
+
+public enum Brand{
+
+  HYUNDAI_ORIGINALS("현대카드의 오리지널리티를 담은 진정한 현대카드"),
+  AMERICAN_EXPRESS("don't live life without it"),
+  CHAMPION_BRANDS("최고의 브랜드와 콜라보한 또 하나의 현대 카드");
+
+  private final String slogan;
+
+  Brand(String slogan) {
+    this.slogan = slogan;
+  }
+
+  public String getSlogan() {
+    return slogan;
+  }
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Card.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Card.java
@@ -1,15 +1,61 @@
 package org.soptcollab.web1.hyundaicard.domain.card;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.soptcollab.web1.hyundaicard.Image.Image;
+import org.soptcollab.web1.hyundaicard.cardtag.CardTag;
 import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Card extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private String id;
+
+  @OneToOne // 1대1 단방향. 일단, image 쪽에는 card 참조를 두지 않았음.
+  @JoinColumn(name = "IMAGE_ID") // Card 엔티티의 Image 가 fk 와 매핑
+  private Image image;
+
+  @OneToMany(mappedBy = "card")
+  private List<CardTag> cardTags = new ArrayList<>();
+
+  @Column(name = "CARD_NAME")
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  private PaymentNetwork paymentNetwork;
+
+  @Enumerated(EnumType.STRING)
+  private Brand brand;
+
+
+  private String benefits;
+
+  private String buttonNote;
+
+
+
+
+
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Card.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/Card.java
@@ -25,8 +25,6 @@ import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class Card extends BaseEntity {
 
   @Id
@@ -49,13 +47,19 @@ public class Card extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private Brand brand;
 
-
   private String benefits;
 
   private String buttonNote;
 
-
-
-
-
+  @Builder
+  public Card(final Image image, final String name, final PaymentNetwork paymentNetwork,
+      final Brand brand, final String benefits,
+      final String buttonNote) {
+    this.image = image;
+    this.name = name;
+    this.paymentNetwork = paymentNetwork;
+    this.brand = brand;
+    this.benefits = benefits;
+    this.buttonNote = buttonNote;
+  }
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/PaymentNetwork.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/domain/card/PaymentNetwork.java
@@ -1,0 +1,5 @@
+package org.soptcollab.web1.hyundaicard.domain.card;
+
+public enum PaymentNetwork {
+  VISA, MASTER, AMEX
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/global/util/SystemPrintLoggingUtil.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/global/util/SystemPrintLoggingUtil.java
@@ -40,6 +40,6 @@ public class SystemPrintLoggingUtil implements LoggingUtil {
         .append("\n| stackTrace: ")
         .append(stackTraceElements[0]);
 
-    System.out.println(log);
+    System.err.println(log);
   }
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
@@ -1,7 +1,6 @@
-package org.soptcollab.web1.hyundaicard;
+package org.soptcollab.web1.hyundaicard.infrastructure.init;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.soptcollab.web1.hyundaicard.Image.Image;

--- a/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
@@ -15,6 +15,7 @@ import org.soptcollab.web1.hyundaicard.domain.card.Brand;
 import org.soptcollab.web1.hyundaicard.domain.card.Card;
 import org.soptcollab.web1.hyundaicard.domain.card.CardRepository;
 import org.soptcollab.web1.hyundaicard.domain.card.PaymentNetwork;
+import org.soptcollab.web1.hyundaicard.global.util.LoggingUtil;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;
 import org.w3c.dom.Document;
@@ -27,6 +28,7 @@ public class CardImageDataLoader implements CommandLineRunner {
   private final S3Service s3Service;
   private final ImageRepository imageRepository;
   private final CardRepository cardRepository;
+  private final LoggingUtil loggingUtil;
 
   @Override
   public void run(String... args) {
@@ -63,7 +65,8 @@ public class CardImageDataLoader implements CommandLineRunner {
                 .height(height)
                 .build();
           } catch (Exception e) {
-            System.err.println("SVG 메타데이터 추출 실패: " + url);
+            loggingUtil.error(e);
+            loggingUtil.info("SVG 메타데이터 추출 실패: " + url);
             return null;
           }
         })
@@ -103,7 +106,7 @@ public class CardImageDataLoader implements CommandLineRunner {
         .toList();
     cardRepository.saveAll(cards);
 
-    System.out.println(">>> S3 기반 더미 Card & Image 로드 완료!");
+    loggingUtil.info(">>> S3 기반 더미 Card & Image 로드 완료!");
   }
 
   private static int parseSvgSize(String sizeStr) {

--- a/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/TagDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/TagDataLoader.java
@@ -1,4 +1,4 @@
-package org.soptcollab.web1.hyundaicard;
+package org.soptcollab.web1.hyundaicard.infrastructure.init;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/soptcollab/web1/hyundaicard/tag/Category.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/tag/Category.java
@@ -1,0 +1,21 @@
+package org.soptcollab.web1.hyundaicard.tag;
+
+public enum Category {
+
+  SHOPPING_CONSUMPTION("쇼핑/소비"), // 쇼핑/소비
+  TRAVEL_GLOBAL("여행/글로벌"), // 여행/글로벌
+  MOVEMENT_TRANSPORTATION("이동/교통"), // 이동/교통
+  LIFESTYLE_CONVENIENCE("생활/편의"), // 생활/편의
+  FINANCE_BUSINESS("금융/사업");// 금융/사업
+
+  private final String type;
+
+  Category(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/tag/Tag.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/tag/Tag.java
@@ -1,0 +1,38 @@
+package org.soptcollab.web1.hyundaicard.tag;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id; // 태그 아이디
+
+  private String name; // 사용자에게 노출되는 태그 명
+
+  private String code; // 내부 식별용 코드
+
+  @Enumerated(EnumType.STRING)
+  private Category category;
+
+  private Integer displayOrder;
+
+  private String hoverText; // 태그 호버시 나오는 메시지(ex. 온라인 쇼핑몰 결제시 추가 적립)
+
+
+}

--- a/src/main/java/org/soptcollab/web1/hyundaicard/tag/Tag.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/tag/Tag.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +14,6 @@ import org.soptcollab.web1.hyundaicard.global.common.entity.BaseEntity;
 
 @Entity
 @Getter
-@Builder @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag extends BaseEntity {
 
@@ -33,6 +31,16 @@ public class Tag extends BaseEntity {
   private Integer displayOrder;
 
   private String hoverText; // 태그 호버시 나오는 메시지(ex. 온라인 쇼핑몰 결제시 추가 적립)
+
+  @Builder
+  public Tag(final String name, final String code, final Category category,
+      final Integer displayOrder, final String hoverText) {
+    this.name = name;
+    this.code = code;
+    this.category = category;
+    this.displayOrder = displayOrder;
+    this.hoverText = hoverText;
+  }
 
 
 }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/tag/TagRepository.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/tag/TagRepository.java
@@ -1,0 +1,7 @@
+package org.soptcollab.web1.hyundaicard.tag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, String> {
+
+}


### PR DESCRIPTION
메인페이지 카드 리스트 조회  API 구현을 완료하였습니다.
태그 리스트 조회 API 구현을 완료하였습니다.

해당 API 구현을 위한 엔티티를 추가하였습니다.
API 반환 값 테스트를 위해 더미데이터를 생성하는 클래스를 만들어주었습니다.

-------

메인페이지 카드 리스트 조회 API
<img width="860" alt="image" src="https://github.com/user-attachments/assets/8014ab11-6bc5-4f18-a529-a1ab4cdda483" />
 
name 부분에서 수정이 필요합니다. 현재 S3 에 저장되어 있는 파일의 이름을 고치면 해결됩니다.


-----

태그 리스트 조회 API 
<img width="536" alt="image" src="https://github.com/user-attachments/assets/6089a7ba-c584-4365-b7fc-f4cdfb655bd9" />

정상적으로 출력됩니다.

