### PR TITLE
refactor : 카드 리스트 DTO 반환을 brand 기준으로 묶어서 하도록 수정

### DIFF
--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.soptcollab.web1.hyundaicard.api.service.card.CardService;
+import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardBrandGroupDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardResponseDto;
 import org.soptcollab.web1.hyundaicard.global.common.response.ApiResponse;
 import org.springframework.http.HttpEntity;
@@ -22,9 +23,9 @@ public class CardController {
    * @return 메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.
    */
   @GetMapping("/cards")
-  public ResponseEntity<ApiResponse<List<CardResponseDto>>> getCardList() {
+  public ResponseEntity<ApiResponse<List<CardBrandGroupDto>>> getCardList() {
 
-    List<CardResponseDto> cards = cardService.findAll();
+    List<CardBrandGroupDto> cards = cardService.findUpTo15();
 
     return ResponseEntity.ok(ApiResponse.success(cards));
   }

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
@@ -1,8 +1,10 @@
 package org.soptcollab.web1.hyundaicard.api.service.card;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardBrandGroupDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardResponseDto;
 import org.soptcollab.web1.hyundaicard.domain.card.Card;
 import org.soptcollab.web1.hyundaicard.domain.card.CardRepository;
@@ -14,11 +16,24 @@ public class CardService {
 
   private final CardRepository cardRepository;
 
-  public List<CardResponseDto> findAll() {
+  public List<CardBrandGroupDto> findUpTo15() {
 
-    return cardRepository.findAll().stream()
-        .limit(15) //15개까지만 조회
-        .map(card -> CardResponseDto.from(card))
-        .collect(Collectors.toList());
+    List<CardResponseDto> allCards = cardRepository.findAll().stream()
+        .limit(15) // 최대 15개까지만 조회
+        .map(CardResponseDto::from)
+        .toList();
+
+    // Car
+    Map<String, List<CardResponseDto>> groupedByBrand = allCards.stream()
+        .collect(Collectors.groupingBy(CardResponseDto::brand));
+
+    return groupedByBrand.entrySet().stream()
+        .map(entry -> new CardBrandGroupDto(entry.getKey(), entry.getValue()))
+        .toList();
   }
 }
+
+
+
+
+

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardBrandGroupDto.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/dto/CardBrandGroupDto.java
@@ -1,0 +1,7 @@
+package org.soptcollab.web1.hyundaicard.api.service.card.dto;
+
+import java.util.List;
+
+public record CardBrandGroupDto(String brand, List<CardResponseDto> cards) {
+
+}


### PR DESCRIPTION
관련이슈 : #17 

![image](https://github.com/user-attachments/assets/57ba6e8e-dbde-4d72-af24-41aaa08ce773)


기존의 방식에서, 위 이미지처럼 brand 별로 카드 리스트를 묶어서 반환하도록 코드를 수정했습니다.






