### PR TITLE
refactor : 브랜드별로 가로,세로가 일관되지 않게 반환되는 문제 수정

### DIFF
--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/controller/card/CardController.java
@@ -3,8 +3,11 @@ package org.soptcollab.web1.hyundaicard.api.controller.card;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.soptcollab.web1.hyundaicard.api.service.card.CardService;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardBrandGroupDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardSearchRequestDto;
@@ -23,34 +26,33 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = " 카드 api", description = "카드 리스트, 카드 검색 api")
 public class CardController {
 
-  private final CardService cardService;
+	private final CardService cardService;
 
-  /**
-   * @return 메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.
-   */
-  @GetMapping
-  @Operation(summary = "카드 리스트", description = "메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.")
-  public ResponseEntity<ApiResponse<List<CardBrandGroupDto>>> getCardList() {
+	/**
+	 * @return 메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.
+	 */
+	@GetMapping
+	@Operation(summary = "카드 리스트", description = "메인페이지의 카드 개수가 15개인 것을 고려하여 15개의 카드 정보를 반환합니다.")
+	public ResponseEntity<ApiResponse<List<CardBrandGroupDto>>> getCardList() {
 
-    List<CardBrandGroupDto> cards = cardService.findUpTo15();
+		List<CardBrandGroupDto> cards = cardService.findGroupedCards();
 
-    return ResponseEntity.ok(ApiResponse.success(cards));
-  }
+		return ResponseEntity.ok(ApiResponse.success(cards));
+	}
 
+	@PostMapping("/search")
+	@Operation(summary = "카드 검색",
+		description = "카드 검색 페이지에서 검색 결과를 반환합니다.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			required = true,
+			content = @Content(mediaType = "application/json")
+		)
+	)
+	public ResponseEntity<ApiResponse<CardSearchResponseDto>> searchCards(
+		@RequestBody CardSearchRequestDto cardSearchRequestDto) {
 
-  @PostMapping("/search")
-  @Operation(summary = "카드 검색",
-      description = "카드 검색 페이지에서 검색 결과를 반환합니다.",
-      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
-          required = true,
-          content = @Content(mediaType = "application/json")
-      )
-  )
-  public ResponseEntity<ApiResponse<CardSearchResponseDto>> searchCards(
-      @RequestBody CardSearchRequestDto cardSearchRequestDto) {
-
-    return ResponseEntity.ok(ApiResponse.success(cardService.searchCards(cardSearchRequestDto)));
-  }
+		return ResponseEntity.ok(ApiResponse.success(cardService.searchCards(cardSearchRequestDto)));
+	}
 }
 
 

--- a/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/api/service/card/CardService.java
@@ -1,16 +1,20 @@
 package org.soptcollab.web1.hyundaicard.api.service.card;
 
 import jakarta.persistence.Tuple;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardBrandGroupDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardResponseDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardSearchRequestDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardSearchResponseDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardSearchResponseDto.RecommendationCategoriesDto;
 import org.soptcollab.web1.hyundaicard.api.service.card.dto.CardSearchResponseDto.SearchedCardDto;
+import org.soptcollab.web1.hyundaicard.domain.card.Brand;
 import org.soptcollab.web1.hyundaicard.domain.card.Card;
 import org.soptcollab.web1.hyundaicard.domain.card.CardRepository;
 import org.soptcollab.web1.hyundaicard.global.common.enums.ErrorCode;
@@ -24,104 +28,126 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CardService {
 
-  private final CardRepository cardRepository;
-  private final TagRepository tagRepository;
+	private final CardRepository cardRepository;
+	private final TagRepository tagRepository;
 
-  public List<CardBrandGroupDto> findUpTo15() {
+	public List<CardBrandGroupDto> findGroupedCards() {
+		List<Card> cards = cardRepository.findAll();
 
-    List<CardResponseDto> allCards = cardRepository.findAll().stream()
-        .limit(15) // 최대 15개까지만 조회
-        .map(CardResponseDto::from)
-        .toList();
+		// 브랜드별로 다른 조건으로 필터링
+		Map<String, List<Card>> filteredGrouped = cards.stream()
+			.filter(card -> {
+				int height = card.getImage().getHeight();
+				Brand brand = card.getBrand();
+				if (brand == Brand.AMERICAN_EXPRESS) {
+					return height <= 200; // 가로만
+				} else {
+					return height > 200;  // 세로만
+				}
+			})
+			.collect(Collectors.groupingBy(card -> card.getBrand().name()));
 
-    // Car
-    Map<String, List<CardResponseDto>> groupedByBrand = allCards.stream()
-        .collect(Collectors.groupingBy(CardResponseDto::brand));
+		// 브랜드별 개수 제한
+		Map<String, Integer> brandLimits = Map.of(
+			"HYUNDAI_ORIGINALS", 3,
+			"AMERICAN_EXPRESS", 3,
+			"CHAMPION_BRANDS", 8
+		);
 
-    return groupedByBrand.entrySet().stream()
-        .map(entry -> new CardBrandGroupDto(entry.getKey(), entry.getValue()))
-        .toList();
-  }
+		return brandLimits.entrySet().stream()
+			.map(entry -> {
+				String brand = entry.getKey();
+				int limit = entry.getValue();
 
-  /**
-   * 검색 조건에 따라 카드 검색
-   *
-   * @param cardSearchRequestDto card 검색 조건 dto
-   * @return 카드 검색 응답 dto
-   */
-  public CardSearchResponseDto searchCards(
-      final CardSearchRequestDto cardSearchRequestDto) {
+				List<CardResponseDto> dtos = filteredGrouped.getOrDefault(brand, List.of())
+					.stream()
+					.limit(limit)
+					.map(CardResponseDto::from)
+					.toList();
 
-    List<String> tagIds = cardSearchRequestDto.filters().tagIds();
+				return new CardBrandGroupDto(brand, dtos);
+			})
+			.toList();
+	}
 
-    // 메인 카드는 이미지가 세로인 카드에서만 검색
-    // 추천 카드는 이미지가 가로인 카드에서만 검색
-    Card mainCard = fetchMainCard(tagIds);
-    List<Card> recommendedCards = fetchRecommendedCards(tagIds);
-    List<Tag> selectedTags = fetchSelectedTag(tagIds);
+	/**
+	 * 검색 조건에 따라 카드 검색
+	 *
+	 * @param cardSearchRequestDto card 검색 조건 dto
+	 * @return 카드 검색 응답 dto
+	 */
+	public CardSearchResponseDto searchCards(
+		final CardSearchRequestDto cardSearchRequestDto) {
 
-    return getCardSearchResponseDto(mainCard, selectedTags, recommendedCards);
-  }
+		List<String> tagIds = cardSearchRequestDto.filters().tagIds();
 
-  private List<Tag> fetchSelectedTag(final List<String> tagIds) {
-    return tagRepository.findAllByIdIn(tagIds);
-  }
+		// 메인 카드는 이미지가 세로인 카드에서만 검색
+		// 추천 카드는 이미지가 가로인 카드에서만 검색
+		Card mainCard = fetchMainCard(tagIds);
+		List<Card> recommendedCards = fetchRecommendedCards(tagIds);
+		List<Tag> selectedTags = fetchSelectedTag(tagIds);
 
+		return getCardSearchResponseDto(mainCard, selectedTags, recommendedCards);
+	}
 
-  /**
-   * 선택한 태그 아이디를 가장 많이 가지는 메인 카드 fetch
-   *
-   * @param tagIds 선택 태그 아이디
-   * @return 메인 카드
-   */
-  private Card fetchMainCard(final List<String> tagIds) {
-    Tuple mainCardResult = cardRepository.getVerticalCardOrderByTags(tagIds)
-        .orElseThrow(() -> new ApiException(
-            ErrorCode.INTERNAL_SERVER_ERROR));
+	private List<Tag> fetchSelectedTag(final List<String> tagIds) {
+		return tagRepository.findAllByIdIn(tagIds);
+	}
 
-    return mainCardResult.get("cardResult", Card.class);
-  }
+	/**
+	 * 선택한 태그 아이디를 가장 많이 가지는 메인 카드 fetch
+	 *
+	 * @param tagIds 선택 태그 아이디
+	 * @return 메인 카드
+	 */
+	private Card fetchMainCard(final List<String> tagIds) {
+		Tuple mainCardResult = cardRepository.getVerticalCardOrderByTags(tagIds)
+			.orElseThrow(() -> new ApiException(
+				ErrorCode.INTERNAL_SERVER_ERROR));
 
-  /**
-   * 선택한 태그 아이디 기준으로 추천카드 fetch
-   *
-   * @param tagIds 선택 태그 아이디
-   * @return 카드 리스트
-   */
-  private List<Card> fetchRecommendedCards(final List<String> tagIds) {
-    List<Tuple> cardResults = cardRepository.getHorizontalCardOrderByTags(tagIds,
-        PageRequest.of(0, 2));
+		return mainCardResult.get("cardResult", Card.class);
+	}
 
-    return cardResults.stream()
-        .map(cardResult -> cardResult.get("cardResult", Card.class))
-        .toList();
-  }
+	/**
+	 * 선택한 태그 아이디 기준으로 추천카드 fetch
+	 *
+	 * @param tagIds 선택 태그 아이디
+	 * @return 카드 리스트
+	 */
+	private List<Card> fetchRecommendedCards(final List<String> tagIds) {
+		List<Tuple> cardResults = cardRepository.getHorizontalCardOrderByTags(tagIds,
+			PageRequest.of(0, 2));
 
-  /**
-   * @param mainCard         메인카드
-   * @param recommendedCards 추천 카드
-   * @return 응답 dto
-   */
-  private CardSearchResponseDto getCardSearchResponseDto(
-      final Card mainCard,
-      final List<Tag> tags,
-      final List<Card> recommendedCards
-  ) {
+		return cardResults.stream()
+			.map(cardResult -> cardResult.get("cardResult", Card.class))
+			.toList();
+	}
 
-    return CardSearchResponseDto.builder()
-        .mainCard(
-            SearchedCardDto.from(mainCard)
-        )
-        .recommendationCategoriesDto(
-            RecommendationCategoriesDto.from(tags)
-        )
-        .otherRecommendationCards(
-            recommendedCards.stream()
-                .map(SearchedCardDto::from)
-                .toList()
-        )
-        .build();
-  }
+	/**
+	 * @param mainCard         메인카드
+	 * @param recommendedCards 추천 카드
+	 * @return 응답 dto
+	 */
+	private CardSearchResponseDto getCardSearchResponseDto(
+		final Card mainCard,
+		final List<Tag> tags,
+		final List<Card> recommendedCards
+	) {
+
+		return CardSearchResponseDto.builder()
+			.mainCard(
+				SearchedCardDto.from(mainCard)
+			)
+			.recommendationCategoriesDto(
+				RecommendationCategoriesDto.from(tags)
+			)
+			.otherRecommendationCards(
+				recommendedCards.stream()
+					.map(SearchedCardDto::from)
+					.toList()
+			)
+			.build();
+	}
 
 }
 

--- a/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
+++ b/src/main/java/org/soptcollab/web1/hyundaicard/infrastructure/init/CardImageDataLoader.java
@@ -1,11 +1,15 @@
 package org.soptcollab.web1.hyundaicard.infrastructure.init;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
+
 import javax.xml.parsers.DocumentBuilderFactory;
+
 import lombok.RequiredArgsConstructor;
+
 import org.soptcollab.web1.hyundaicard.Image.Image;
 import org.soptcollab.web1.hyundaicard.Image.ImageRepository;
 import org.soptcollab.web1.hyundaicard.api.service.s3.S3Service;
@@ -23,93 +27,110 @@ import org.w3c.dom.Element;
 @RequiredArgsConstructor
 public class CardImageDataLoader implements CommandLineRunner {
 
-  private final S3Service s3Service;
-  private final ImageRepository imageRepository;
-  private final CardRepository cardRepository;
-  private final LoggingUtil loggingUtil;
+	private final S3Service s3Service;
+	private final ImageRepository imageRepository;
+	private final CardRepository cardRepository;
+	private final LoggingUtil loggingUtil;
 
-  @Override
-  public void run(String... args) {
-    if (cardRepository.count() > 0) {
-      return;
-    }
+	@Override
+	public void run(String... args) {
+		if (cardRepository.count() > 0) {
+			return;
+		}
 
-    // 1) S3에서 card-thumbnails 디렉터리의 URL 리스트 가져오기
-    List<String> urls = s3Service.listFiles("card-thumbnails");
+		// 1) S3에서 card-thumbnails 디렉터리의 URL 리스트 가져오기
+		List<String> urls = s3Service.listFiles("card-thumbnails");
 
-    // 2) Image 엔티티로 저장
-    List<Image> images = urls.stream()
-        .map(url -> {
-          try {
-            String fileName = url.substring(url.lastIndexOf('/') + 1);
-            String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
+		// 2) Image 엔티티로 저장
+		List<Image> images = urls.stream()
+			.map(url -> {
+				try {
+					String fileName = url.substring(url.lastIndexOf('/') + 1);
+					String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
 
-            Document doc = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(new URL(url).openStream());
+					Document doc = DocumentBuilderFactory.newInstance()
+						.newDocumentBuilder()
+						.parse(new URL(url).openStream());
 
-            Element svgElement = doc.getDocumentElement();
+					Element svgElement = doc.getDocumentElement();
 
-            String widthStr = svgElement.getAttribute("width");
-            String heightStr = svgElement.getAttribute("height");
+					String widthStr = svgElement.getAttribute("width");
+					String heightStr = svgElement.getAttribute("height");
 
-            int width = parseSvgSize(widthStr);
-            int height = parseSvgSize(heightStr);
+					int width = parseSvgSize(widthStr);
+					int height = parseSvgSize(heightStr);
 
-            return Image.builder()
-                .url(url)
-                .extension(extension)
-                .width(width)
-                .height(height)
-                .build();
-          } catch (Exception e) {
-            loggingUtil.error(e);
-            loggingUtil.info("SVG 메타데이터 추출 실패: " + url);
-            return null;
-          }
-        })
-        .filter(Objects::nonNull)
-        .toList();
+					return Image.builder()
+						.url(url)
+						.extension(extension)
+						.width(width)
+						.height(height)
+						.build();
+				} catch (Exception e) {
+					loggingUtil.error(e);
+					loggingUtil.info("SVG 메타데이터 추출 실패: " + url);
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList();
 
-    imageRepository.saveAll(images);
+		imageRepository.saveAll(images);
 
-    // 3) Brand, PaymentNetwork 순환 배열 준비
-    Brand[] brands = Brand.values();
-    PaymentNetwork[] networks = PaymentNetwork.values();
+		// 3) Brand, PaymentNetwork 순환 배열 준비
+		Brand[] brands = Brand.values();
+		PaymentNetwork[] networks = PaymentNetwork.values();
 
-    // 4) Image 리스트 인덱스를 활용해 Card 더미 생성
-    List<Card> cards = IntStream.range(0, images.size())
-        .mapToObj(idx -> {
-          Image img = images.get(idx);
+		// 4) Image 리스트 인덱스를 활용해 Card 더미 생성
+		List<Card> cards = IntStream.range(0, images.size())
+			.mapToObj(idx -> {
+				Image img = images.get(idx);
+				String fileName = img.getUrl().substring(img.getUrl().lastIndexOf('/') + 1);
+				String displayName = fileName.replace("." + img.getExtension(), "");
+				String lowerName = displayName.toLowerCase();
 
-          // URL에서 파일명 → displayName 생성
-          String fileName = img.getUrl().substring(img.getUrl().lastIndexOf('/') + 1);
-          String displayName = fileName.replace("." + img.getExtension(), "");
-//          String displayName = base.replace('_', ' ');
+				// 브랜드 결정
+				Brand brand;
+				if (lowerName.contains("american")) {
+					brand = Brand.AMERICAN_EXPRESS;
+				} else if (matchesAny(lowerName, "red", "green", "pink", "summit", "olive")) {
+					brand = Brand.HYUNDAI_ORIGINALS;
+				} else if (matchesAny(lowerName,
+					"delivery", "korean_air", "musinsa", "korean_air-1", "ssg",
+					"boutique_velvet", "emart", "hmall", "naver", "gs", "musinsa-1", "costco")) {
+					brand = Brand.CHAMPION_BRANDS;
+				} else {
+					brand = Brand.HYUNDAI_ORIGINALS; // fallback
+				}
 
-          Brand brand = brands[idx % brands.length];
-          PaymentNetwork network = networks[idx % networks.length];
-          String benefits = brand.getSlogan();
-          String buttonNote = "지금 신청하기";
+				PaymentNetwork network = networks[idx % networks.length];
+				String benefits = brand.getSlogan();
+				String buttonNote = "지금 신청하기";
 
-          return Card.builder()
-              .name(displayName)
-              .brand(brand)
-              .paymentNetwork(network)
-              .benefits(benefits)
-              .buttonNote(buttonNote)
-              .image(img)
-              .build();
-        })
-        .toList();
-    cardRepository.saveAll(cards);
+				return Card.builder()
+					.name(displayName)
+					.brand(brand)
+					.paymentNetwork(network)
+					.benefits(benefits)
+					.buttonNote(buttonNote)
+					.image(img)
+					.build();
+			})
+			.toList();
 
-    loggingUtil.info(">>> S3 기반 더미 Card & Image 로드 완료!");
-  }
+		cardRepository.saveAll(cards);
 
-  private static int parseSvgSize(String sizeStr) {
-    if (sizeStr == null || sizeStr.isEmpty()) return 0;
-    return (int) Double.parseDouble(sizeStr.replaceAll("[^0-9.]", ""));
-  }
+		loggingUtil.info(">>> S3 기반 더미 Card & Image 로드 완료!");
+	}
+
+	private boolean matchesAny(String target, String... keywords) {
+		return Arrays.stream(keywords).anyMatch(target::contains);
+	}
+
+	private static int parseSvgSize(String sizeStr) {
+		if (sizeStr == null || sizeStr.isEmpty())
+			return 0;
+		return (int)Double.parseDouble(sizeStr.replaceAll("[^0-9.]", ""));
+	}
 
 }


### PR DESCRIPTION
AMERICAN EXPRESS 카드는 가로로 출력되어야하고,
나머지 카드들은 세로로 출력되어야 합니다.

기존에는 모든 카드들을 필터링 없이 가져와서 반환했기에 위와 같은 부분들을 고려하지 않았습니다.

위 문제를 해결하기 위해 AMERICAN EXPRESS 카드를 가져올때는 필터링 조건을 height < 200으로,
나머지 브랜드의 카드를 가져올 때는 필터링 조건을 height >= 200 으로 걸어주었습니다.

-----

추가적으로, 카드 더미 데이터를 생성할때, 카드의 이름만 봤을때는 Hyndai Originals 카드인데, 브랜드를 살펴보니 AMERICAN_EXPRESS 인 경우도 있었습니다. 카드 이름에 맞추어 브랜드가 만들어지도록 수정하였습니다.